### PR TITLE
Making separate versions of CallWebhookJob for Laravel and Lumen without breaking changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,21 @@ return [
 
 By default, the package uses queues to retry failed webhook requests. Be sure to set up a real queue other than `sync` in non-local environments.
 
+### Lumen
+
+Some manual steps are needed to set this up in Lumen.
+
+Copy the config file:
+
+    mkdir -p config
+    cp vendor/spatie/laravel-webhook-server/config/webhook-server.php config/
+
+In `bootstrap/app.php` register the service provider:
+
+    $app->register(Spatie\WebhookServer\WebhookServerServiceProvider::class);
+
+Make sure eloquent is enabled:
+
 ## Usage
 
 This is the simplest way to call a webhook:

--- a/src/CallWebhookJobAbstract.php
+++ b/src/CallWebhookJobAbstract.php
@@ -4,14 +4,14 @@ namespace Spatie\WebhookServer;
 
 use Exception;
 use GuzzleHttp\Client;
-use Illuminate\Bus\Queueable;
-use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Str;
-use Spatie\WebhookServer\Events\FinalWebhookCallFailedEvent;
+use Illuminate\Bus\Queueable;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Spatie\WebhookServer\Events\WebhookCallFailedEvent;
 use Spatie\WebhookServer\Events\WebhookCallSucceededEvent;
+use Spatie\WebhookServer\Events\FinalWebhookCallFailedEvent;
 
 abstract class CallWebhookJobAbstract implements ShouldQueue
 {
@@ -71,7 +71,7 @@ abstract class CallWebhookJobAbstract implements ShouldQueue
                 'headers' => $this->headers,
             ]);
 
-            if (!Str::startsWith($this->response->getStatusCode(), 2)) {
+            if (! Str::startsWith($this->response->getStatusCode(), 2)) {
                 throw new Exception('Webhook call failed');
             }
 

--- a/src/CallWebhookJobAbstract.php
+++ b/src/CallWebhookJobAbstract.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Spatie\WebhookServer;
+
+use Exception;
+use GuzzleHttp\Client;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Str;
+use Spatie\WebhookServer\Events\FinalWebhookCallFailedEvent;
+use Spatie\WebhookServer\Events\WebhookCallFailedEvent;
+use Spatie\WebhookServer\Events\WebhookCallSucceededEvent;
+
+abstract class CallWebhookJobAbstract implements ShouldQueue
+{
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    /** @var string */
+    public $webhookUrl;
+
+    /** @var string */
+    public $httpVerb;
+
+    /** @var int */
+    public $tries;
+
+    /** @var int */
+    public $requestTimeout;
+
+    /** @var string */
+    public $backoffStrategyClass;
+
+    /** @var string */
+    public $signerClass;
+
+    /** @var array */
+    public $headers = [];
+
+    /** @var bool */
+    public $verifySsl;
+
+    /** @var string */
+    public $queue;
+
+    /** @var array */
+    public $payload = [];
+
+    /** @var array */
+    public $meta = [];
+
+    /** @var array */
+    public $tags = [];
+
+    /** @var \GuzzleHttp\Psr7\Response|null */
+    private $response;
+
+    public function handle()
+    {
+        /** @var \GuzzleHttp\Client $client */
+        $client = app(Client::class);
+
+        try {
+            $this->response = $client->request($this->httpVerb, $this->webhookUrl, [
+                'timeout' => $this->requestTimeout,
+                'body' => json_encode($this->payload),
+                'verify' => $this->verifySsl,
+                'headers' => $this->headers,
+            ]);
+
+            if (!Str::startsWith($this->response->getStatusCode(), 2)) {
+                throw new Exception('Webhook call failed');
+            }
+
+            $this->dispatchEvent(WebhookCallSucceededEvent::class);
+        } catch (Exception $exception) {
+            /** @var \Spatie\WebhookServer\BackoffStrategy\BackoffStrategy $backoffStrategry */
+            $backoffStrategy = app($this->backoffStrategyClass);
+
+            $waitInSeconds = $backoffStrategy->waitInSecondsAfterAttempt($this->attempts());
+
+            $this->dispatchEvent(WebhookCallFailedEvent::class);
+
+            $this->release($waitInSeconds);
+        }
+
+        if ($this->attempts() >= $this->tries) {
+            $this->dispatchEvent(FinalWebhookCallFailedEvent::class);
+
+            $this->delete();
+        }
+    }
+
+    private function dispatchEvent(string $eventClass)
+    {
+        event(new $eventClass(
+            $this->httpVerb,
+            $this->webhookUrl,
+            $this->payload,
+            $this->headers,
+            $this->meta,
+            $this->tags,
+            $this->attempts(),
+            $this->response,
+        ));
+    }
+
+    public function tags()
+    {
+        return $this->tags;
+    }
+}

--- a/src/CallWebhookJobLumen.php
+++ b/src/CallWebhookJobLumen.php
@@ -4,7 +4,7 @@ namespace Spatie\WebhookServer;
 
 use Illuminate\Foundation\Bus\Dispatchable;
 
-class CallWebhookJob extends CallWebhookJobAbstract
+class CallWebhookJobLumen extends CallWebhookJobAbstract
 {
-    use Dispatchable;
+    // without Dispatchable
 }

--- a/src/WebhookCall.php
+++ b/src/WebhookCall.php
@@ -92,7 +92,7 @@ class WebhookCall
 
     public function useBackoffStrategy(string $backoffStrategyClass)
     {
-        if (!is_subclass_of($backoffStrategyClass, BackoffStrategy::class)) {
+        if (! is_subclass_of($backoffStrategyClass, BackoffStrategy::class)) {
             throw InvalidBackoffStrategy::doesNotExtendBackoffStrategy($backoffStrategyClass);
         }
 
@@ -110,7 +110,7 @@ class WebhookCall
 
     public function signUsing(string $signerClass)
     {
-        if (!is_subclass_of($signerClass, Signer::class)) {
+        if (! is_subclass_of($signerClass, Signer::class)) {
             throw InvalidSigner::doesImplementSigner($signerClass);
         }
 
@@ -156,7 +156,7 @@ class WebhookCall
 
     public function dispatch(): void
     {
-        if (!$this->callWebhookJob->webhookUrl) {
+        if (! $this->callWebhookJob->webhookUrl) {
             throw CouldNotCallWebhook::urlNotSet();
         }
 

--- a/src/WebhookCall.php
+++ b/src/WebhookCall.php
@@ -43,7 +43,7 @@ class WebhookCall
 
     public function __construct()
     {
-        $this->callWebhookJob = app(CallWebhookJob::class);
+        $this->callWebhookJob = app(CallWebhookJobAbstract::class);
     }
 
     public function url(string $url)
@@ -92,7 +92,7 @@ class WebhookCall
 
     public function useBackoffStrategy(string $backoffStrategyClass)
     {
-        if (! is_subclass_of($backoffStrategyClass, BackoffStrategy::class)) {
+        if (!is_subclass_of($backoffStrategyClass, BackoffStrategy::class)) {
             throw InvalidBackoffStrategy::doesNotExtendBackoffStrategy($backoffStrategyClass);
         }
 
@@ -110,7 +110,7 @@ class WebhookCall
 
     public function signUsing(string $signerClass)
     {
-        if (! is_subclass_of($signerClass, Signer::class)) {
+        if (!is_subclass_of($signerClass, Signer::class)) {
             throw InvalidSigner::doesImplementSigner($signerClass);
         }
 
@@ -156,7 +156,7 @@ class WebhookCall
 
     public function dispatch(): void
     {
-        if (! $this->callWebhookJob->webhookUrl) {
+        if (!$this->callWebhookJob->webhookUrl) {
             throw CouldNotCallWebhook::urlNotSet();
         }
 

--- a/src/WebhookServerServiceProvider.php
+++ b/src/WebhookServerServiceProvider.php
@@ -18,5 +18,11 @@ class WebhookServerServiceProvider extends ServiceProvider
     public function register()
     {
         $this->mergeConfigFrom(__DIR__.'/../config/webhook-server.php', 'webhook-server');
+
+        if (strpos($this->app->version(), 'Lumen') !== false) {
+            $this->app->alias(CallWebhookJob::class, CallWebhookJobAbstract::class);
+        } else {
+            $this->app->alias(CallWebhookJobLumen::class, CallWebhookJobAbstract::class);
+        }
     }
 }

--- a/src/WebhookServerServiceProvider.php
+++ b/src/WebhookServerServiceProvider.php
@@ -20,9 +20,9 @@ class WebhookServerServiceProvider extends ServiceProvider
         $this->mergeConfigFrom(__DIR__.'/../config/webhook-server.php', 'webhook-server');
 
         if (strpos($this->app->version(), 'Lumen') !== false) {
-            $this->app->alias(CallWebhookJob::class, CallWebhookJobAbstract::class);
-        } else {
             $this->app->alias(CallWebhookJobLumen::class, CallWebhookJobAbstract::class);
+        } else {
+            $this->app->alias(CallWebhookJob::class, CallWebhookJobAbstract::class);
         }
     }
 }


### PR DESCRIPTION
Fixes #3 

Laravel users can remain using `CallWebhookJob` as before, without any breaking changes.

Lumen users however, can use `CallWebhookJobLumen`, which is simply a version without the `Dispatchable` trait, which missing in Lumen.