### PR TITLE
remove constructor on WebhookCallFailedEvent so it inherits properties

### DIFF
--- a/src/Events/WebhookCallFailedEvent.php
+++ b/src/Events/WebhookCallFailedEvent.php
@@ -4,7 +4,4 @@ namespace Spatie\WebhookServer\Events;
 
 class WebhookCallFailedEvent extends WebhookCallEvent
 {
-    public function __construct()
-    {
-    }
 }


### PR DESCRIPTION
The empty constructor on the `WebhookCallFailedEvent` is empty and overriding `WebhookCallEvent` so when listening for the job you don't have access to any of the event properties.

Potentially could add something like this in the tests to ensure those properties are available.
```
Event::assertDispatched(WebhookCallFailedEvent::class, function ($event) {
    return $event->webhookUrl === 'https://example.com/webhooks';
});
```