### PR TITLE
correctly set the request headers

### DIFF
--- a/src/WebhookCall.php
+++ b/src/WebhookCall.php
@@ -171,7 +171,10 @@ class WebhookCall
 
     protected function getAllHeaders(): array
     {
-        $headers = $this->headers;
+        $headers = array_merge(
+            config('webhook-server.headers'),
+            $this->headers,
+        );
 
         $signature = $this->signer->calculateSignature($this->payload, $this->secret);
 

--- a/tests/CallWebhookJobTest.php
+++ b/tests/CallWebhookJobTest.php
@@ -144,6 +144,7 @@ class CallWebhookJobTest extends TestCase
                 'body' => json_encode(['a' => 1]),
                 'verify' => true,
                 'headers' => [
+                    'Content-Type' => 'application/json',
                     'Signature' => '1f14a62b15ba5095326d6c75c3e2e6b462dd71e1c4b7fbdac0f32309adb7be5f',
                 ],
             ],

--- a/tests/WebhookTest.php
+++ b/tests/WebhookTest.php
@@ -34,7 +34,7 @@ class WebhookTest extends TestCase
             $this->assertEquals($config['tries'], $job->tries);
             $this->assertEquals($config['timeout_in_seconds'], $job->requestTimeout);
             $this->assertEquals($config['backoff_strategy'], $job->backoffStrategyClass);
-            $this->assertEquals([$config['signature_header_name']], array_keys($job->headers));
+            $this->assertEquals(['Content-Type', $config['signature_header_name']], array_keys($job->headers));
             $this->assertEquals($config['verify_ssl'], $job->verifySsl);
             $this->assertEquals($config['tags'], $job->tags);
 


### PR DESCRIPTION
Headers supplied in the config that were to be added to all webhook requests were being overridden if you add custom headers via `->withHeaders()'.

This PR fixes the tests that are currently failing after the addition of `'Content-Type' => 'application/json'` into ` config/webhook-server.php`