### PR TITLE
Fix syntax error

### DIFF
--- a/src/CallWebhookJob.php
+++ b/src/CallWebhookJob.php
@@ -104,7 +104,7 @@ class CallWebhookJob implements ShouldQueue
             $this->meta,
             $this->tags,
             $this->attempts(),
-            $this->response,
+            $this->response
         ));
     }
 


### PR DESCRIPTION
Tiny typo that causes a syntax error.