### PR TITLE
Set response field on request failure

### DIFF
--- a/src/CallWebhookJob.php
+++ b/src/CallWebhookJob.php
@@ -4,6 +4,7 @@ namespace Spatie\WebhookServer;
 
 use Exception;
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\RequestException;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -75,9 +76,13 @@ class CallWebhookJob implements ShouldQueue
             }
 
             $this->dispatchEvent(WebhookCallSucceededEvent::class);
-            
+
             return;
         } catch (Exception $exception) {
+            if ($exception instanceof RequestException) {
+               $this->response = $exception->getResponse();
+            }
+
             /** @var \Spatie\WebhookServer\BackoffStrategy\BackoffStrategy $backoffStrategy */
             $backoffStrategy = app($this->backoffStrategyClass);
 

--- a/tests/CallWebhookJobTest.php
+++ b/tests/CallWebhookJobTest.php
@@ -131,6 +131,20 @@ class CallWebhookJobTest extends TestCase
         $this->testClient->assertRequestCount(3);
     }
 
+    /** @test */
+    public function it_sets_the_response_field_on_request_failure()
+    {
+        $this->testClient->throwRequestException();
+
+        $this->baseWebhook()->dispatch();
+
+        $this->artisan('queue:work --once');
+        Event::assertDispatched(WebhookCallFailedEvent::class, function (WebhookCallFailedEvent $event) {
+            $this->assertNotNull($event->response);
+            return true;
+        });
+    }
+
     protected function baseWebhook(): WebhookCall
     {
         return WebhookCall::create()

--- a/tests/TestClasses/TestClient.php
+++ b/tests/TestClasses/TestClient.php
@@ -2,6 +2,8 @@
 
 namespace Spatie\WebhookServer\Tests\TestClasses;
 
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\Assert;
 
@@ -11,9 +13,19 @@ class TestClient
 
     private $useResponseCode = 200;
 
+    private $throwRequestException = false;
+
     public function request(string $method, string $url, array $options)
     {
         $this->requests[] = compact('method', 'url', 'options');
+
+        if ($this->throwRequestException) {
+            throw new RequestException(
+                'Request failed exception',
+                new Request($method, $url),
+                new Response(500)
+            );
+        }
 
         return new Response($this->useResponseCode);
     }
@@ -39,5 +51,10 @@ class TestClient
     public function letEveryRequestFail()
     {
         $this->useResponseCode = 500;
+    }
+
+    public function throwRequestException()
+    {
+        $this->throwRequestException = true;
     }
 }


### PR DESCRIPTION
Fixes https://github.com/spatie/laravel-webhook-client/issues/19

(Sorry I created the original issue on the wrong repository 🤣 ).

The new response properties in PR #14 should also be added to the new section added here.