### PR TITLE
Add error info to the dispatched event

### DIFF
--- a/src/CallWebhookJob.php
+++ b/src/CallWebhookJob.php
@@ -58,6 +58,12 @@ class CallWebhookJob implements ShouldQueue
     /** @var \GuzzleHttp\Psr7\Response|null */
     private $response;
 
+	/**	@var string */
+	private $errorType;
+
+	/**	@var string */
+	private $errorMessage;
+
     public function handle()
     {
         /** @var \GuzzleHttp\Client $client */
@@ -83,6 +89,8 @@ class CallWebhookJob implements ShouldQueue
         } catch (Exception $exception) {
             if ($exception instanceof RequestException) {
                 $this->response = $exception->getResponse();
+				$this->errorType = get_class($exception);
+				$this->errorMessage = $exception->getMessage();
             }
 
             if (! $lastAttempt) {
@@ -125,6 +133,8 @@ class CallWebhookJob implements ShouldQueue
             $this->tags,
             $this->attempts(),
             $this->response,
+			$this->errorType,
+			$this->errorMessage
         ));
     }
 }

--- a/src/Events/WebhookCallEvent.php
+++ b/src/Events/WebhookCallEvent.php
@@ -30,6 +30,12 @@ abstract class WebhookCallEvent
     /** @var \GuzzleHttp\Psr7\Response|null */
     public $response;
 
+	/** @var string */
+	public $errorType;
+
+	/** @var string */
+	public $errorMessage;
+
     public function __construct(
         string $httpVerb,
         string $webhookUrl,
@@ -38,7 +44,9 @@ abstract class WebhookCallEvent
         array $meta,
         array $tags,
         int $attempt,
-        ?Response $response
+        ?Response $response,
+		?string $errorType,
+		?string $errorMessage
     ) {
         $this->httpVerb = $httpVerb;
         $this->webhookUrl = $webhookUrl;
@@ -48,5 +56,7 @@ abstract class WebhookCallEvent
         $this->tags = $tags;
         $this->attempt = $attempt;
         $this->response = $response;
+		$this->errorType = $errorType;
+		$this->errorMessage = $errorMessage;
     }
 }

--- a/tests/CallWebhookJobTest.php
+++ b/tests/CallWebhookJobTest.php
@@ -155,6 +155,21 @@ class CallWebhookJobTest extends TestCase
         });
     }
 
+	/** @test */
+	public function it_sets_the_error_fields_on_connection_failure()
+	{
+		$this->testClient->throwConnectionException();
+
+		$this->baseWebhook()->dispatch();
+
+		$this->artisan('queue:work --once');
+		Event::assertDispatched(WebhookCallFailedEvent::class, function (WebhookCallFailedEvent $event) {
+			$this->assertNotNull($event->errorType);
+			$this->assertNotNull($event->errorMessage);
+			return true;
+		});
+	}
+
     protected function baseWebhook(): WebhookCall
     {
         return WebhookCall::create()

--- a/tests/TestClasses/TestClient.php
+++ b/tests/TestClasses/TestClient.php
@@ -2,59 +2,78 @@
 
 namespace Spatie\WebhookServer\Tests\TestClasses;
 
+use GuzzleHttp\Exception\BadResponseException;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\SeekException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use mysql_xdevapi\Exception;
 use PHPUnit\Framework\Assert;
+use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
 
 class TestClient
 {
-    private $requests = [];
+	private $requests = [];
 
-    private $useResponseCode = 200;
+	private $useResponseCode = 200;
 
-    private $throwRequestException = false;
+	private $throwRequestException = false;
 
-    public function request(string $method, string $url, array $options)
-    {
-        $this->requests[] = compact('method', 'url', 'options');
+	private $throwConnectionException = false;
 
-        if ($this->throwRequestException) {
-            throw new RequestException(
-                'Request failed exception',
-                new Request($method, $url),
-                new Response(500)
-            );
-        }
+	public function request(string $method, string $url, array $options)
+	{
+		$this->requests[] = compact('method', 'url', 'options');
 
-        return new Response($this->useResponseCode);
-    }
+		if ($this->throwRequestException) {
+			throw new RequestException(
+				'Request failed exception',
+				new Request($method, $url),
+				new Response(500)
+			);
+		}
 
-    public function assertRequestCount(int $expectedCount)
-    {
-        Assert::assertCount($expectedCount, $this->requests);
+		if ($this->throwConnectionException) {
+			throw new ConnectException(
+				'Request timeout',
+				new Request($method, $url),
+			);
+		}
 
-        return $this;
-    }
+		return new Response($this->useResponseCode);
+	}
 
-    public function assertRequestsMade(array $expectedRequests)
-    {
-        $this->assertRequestCount(count($expectedRequests));
+	public function assertRequestCount(int $expectedCount)
+	{
+		Assert::assertCount($expectedCount, $this->requests);
 
-        foreach ($expectedRequests as $index => $expectedRequest) {
-            foreach ($expectedRequest as $name => $value) {
-                Assert::assertEquals($value, $this->requests[$index][$name]);
-            }
-        }
-    }
+		return $this;
+	}
 
-    public function letEveryRequestFail()
-    {
-        $this->useResponseCode = 500;
-    }
+	public function assertRequestsMade(array $expectedRequests)
+	{
+		$this->assertRequestCount(count($expectedRequests));
 
-    public function throwRequestException()
-    {
-        $this->throwRequestException = true;
-    }
+		foreach ($expectedRequests as $index => $expectedRequest) {
+			foreach ($expectedRequest as $name => $value) {
+				Assert::assertEquals($value, $this->requests[$index][$name]);
+			}
+		}
+	}
+
+	public function letEveryRequestFail()
+	{
+		$this->useResponseCode = 500;
+	}
+
+	public function throwRequestException()
+	{
+		$this->throwRequestException = true;
+	}
+
+	public function throwConnectionException()
+	{
+		$this->throwConnectionException = true;
+	}
 }


### PR DESCRIPTION
Inspired from: https://github.com/spatie/laravel-webhook-server/issues/20

Added more error info to the event which is being sent.

This adds error info to all events which extends the `GuzzleHttp\Exception\RequestException` class.