### PR TITLE
Report Guzzle exception

### DIFF
--- a/src/CallWebhookJob.php
+++ b/src/CallWebhookJob.php
@@ -74,6 +74,8 @@ class CallWebhookJob implements ShouldQueue
 
             return;
         } catch (Exception $exception) {
+            report($exception);
+
             if ($exception instanceof RequestException) {
                 $this->response = $exception->getResponse();
                 $this->errorType = get_class($exception);


### PR DESCRIPTION
I checked the code of the CallWebhookJob class and realized that the exceptions thrown by Guzzle are not printed in the log.

My suggestion is to put a report($exception) on line 77, this will greatly improve our lives, because if errors are not recorded, we have the impression that the task was successfully executed, because there is nothing in the log.