### PR TITLE
Feature #15 dispatchNow

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,17 @@ This will send a post request to `https://other-app.com/webhooks`. The body of t
 
 If the receiving app doesn't respond with a response code starting with `2`, the package will retry calling the webhook after 10 seconds. If that second attempt fails, the package will attempt to call the webhook a final time after 100 seconds. Should that attempt fail, the `FinalWebhookCallFailedEvent` will be raised.
 
+### Send webhook synchronously
+
+If you would like to call the webhook immediately (synchronously), you may use the dispatchNow method. When using this method, the webhook will not be queued and will be run immediately. This can be helpfull in situation where sending the webhook is part of a bigger job that already has been queued.
+
+```php
+WebhookCall::create()
+   ...
+   ->dispatchNow();
+```
+
+
 ### How signing requests works
 
 When setting up, it's common to generate, store, and share a secret between your app and the app that wants to receive webhooks. Generating the secret could be done with `Illuminate\Support\Str::random()`, but it's entirely up to you. The package will use the secret to sign a webhook call.

--- a/src/WebhookCall.php
+++ b/src/WebhookCall.php
@@ -156,6 +156,13 @@ class WebhookCall
         dispatch($this->callWebhookJob);
     }
 
+    public function dispatchNow(): void
+    {
+        $this->prepareForDispatch();
+
+        dispatch_now($this->callWebhookJob);
+    }
+
     protected function prepareForDispatch(): void
     {
         if (! $this->callWebhookJob->webhookUrl) {

--- a/src/WebhookCall.php
+++ b/src/WebhookCall.php
@@ -151,6 +151,13 @@ class WebhookCall
 
     public function dispatch(): void
     {
+        $this->prepareForDispatch();
+
+        dispatch($this->callWebhookJob);
+    }
+
+    protected function prepareForDispatch(): void
+    {
         if (! $this->callWebhookJob->webhookUrl) {
             throw CouldNotCallWebhook::urlNotSet();
         }
@@ -160,8 +167,6 @@ class WebhookCall
         }
 
         $this->callWebhookJob->headers = $this->getAllHeaders();
-
-        dispatch($this->callWebhookJob);
     }
 
     protected function getAllHeaders(): array

--- a/tests/CallWebhookJobTest.php
+++ b/tests/CallWebhookJobTest.php
@@ -42,6 +42,16 @@ class CallWebhookJobTest extends TestCase
     }
 
     /** @test */
+    public function it_can_make_a_synchronous_webhook_call()
+    {
+        $this->baseWebhook()->dispatchNow();
+
+        $this
+            ->testClient
+            ->assertRequestsMade([$this->baseRequest()]);
+    }
+
+    /** @test */
     public function it_can_use_a_different_http_verb()
     {
         $this


### PR DESCRIPTION
Ability to call dispatchNow instead of dispatch so you can use the webhook-package inside another asynchronous job so that whole job can be redone.