### PR TITLE
Adding UUID accessor method

### DIFF
--- a/src/WebhookCall.php
+++ b/src/WebhookCall.php
@@ -72,6 +72,11 @@ class WebhookCall
         return $this;
     }
 
+    public function getUuid(): string
+    {
+        return $this->uuid;
+    }
+
     public function onQueue(string $queue): self
     {
         $this->callWebhookJob->queue = $queue;

--- a/tests/WebhookTest.php
+++ b/tests/WebhookTest.php
@@ -81,4 +81,13 @@ class WebhookTest extends TestCase
 
         WebhookCall::create()->signUsing(static::class);
     }
+
+    /** @test */
+    public function it_can_get_the_uuid_property()
+    {
+        $webhookCall = WebhookCall::create()->uuid('my-unique-identifier');
+
+        $this->assertIsString($webhookCall->getUuid());
+        $this->assertSame('my-unique-identifier', $webhookCall->getUuid());
+    }
 }


### PR DESCRIPTION
One thing that I miss about this package is the ability to get the UUID property of the job being dispatched, and decided to implement this during Hacktoberfest.

## Why this is useful

In my projects, every critical communication that our servers establish with others have to be logged on Elasticsearch. It's important to be able to track things, and UUIDs are excellent for that. By default, when we call `WebhookCall::create()` it will use the default values from the configuration, except for one: the UUID, which is defined in that moment.

To be able to persist and "associate" the job dispatched with the document on Elasticsearch, we are overriding the UUID property, just because we do not have access to the default value created by the package. It is a minor improvement, but one less overhead.

```php
// Before
$webhookCall = WebhookCall::create()
            ->uuid($myIdentification = Str::uuid())
           ->payload($body)
            ->dispatch();

$document = [
            'index' => 'webhooks_dispatched',
            'id' => $myIdentification,
            'body' => $body,
        ];

// After
$webhookCall = WebhookCall::create()
           ->payload($body)
            ->dispatch();

$document = [
            'index' => 'webhooks_dispatched',
            'id' => $webhookCall->getUuid(),
            'body' => $body,
        ];
```