### PR TITLE
Fix exception name for invalid signers

### DIFF
--- a/src/Exceptions/InvalidSigner.php
+++ b/src/Exceptions/InvalidSigner.php
@@ -7,7 +7,7 @@ use Spatie\WebhookServer\Signer\Signer;
 
 class InvalidSigner extends Exception
 {
-    public static function doesImplementSigner(string $invalidClassName): self
+    public static function doesNotImplement(string $invalidClassName): self
     {
         $signerInterface = Signer::class;
 

--- a/src/Exceptions/InvalidSigner.php
+++ b/src/Exceptions/InvalidSigner.php
@@ -7,7 +7,7 @@ use Spatie\WebhookServer\Signer\Signer;
 
 class InvalidSigner extends Exception
 {
-    public static function doesNotImplement(string $invalidClassName): self
+    public static function doesNotImplementSigner(string $invalidClassName): self
     {
         $signerInterface = Signer::class;
 

--- a/src/WebhookCall.php
+++ b/src/WebhookCall.php
@@ -126,7 +126,7 @@ class WebhookCall
     public function signUsing(string $signerClass): self
     {
         if (! is_subclass_of($signerClass, Signer::class)) {
-            throw InvalidSigner::doesNotImplement($signerClass);
+            throw InvalidSigner::doesNotImplementSigner($signerClass);
         }
 
         $this->signer = app($signerClass);

--- a/src/WebhookCall.php
+++ b/src/WebhookCall.php
@@ -126,7 +126,7 @@ class WebhookCall
     public function signUsing(string $signerClass): self
     {
         if (! is_subclass_of($signerClass, Signer::class)) {
-            throw InvalidSigner::doesImplementSigner($signerClass);
+            throw InvalidSigner::doesNotImplement($signerClass);
         }
 
         $this->signer = app($signerClass);


### PR DESCRIPTION
This PR change the method `doesImplementSigner` to `doesNotImplementSigner`, in `InvalidSigner` Exception.

```diff
- public static function doesImplementSigner(string $invalidClassName): self
+ public static function doesNotImplementSigner(string $invalidClassName): self
```