### PR TITLE
Dispatch should return the PendingDispatch.

### DIFF
--- a/src/WebhookCall.php
+++ b/src/WebhookCall.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\WebhookServer;
 
+use Illuminate\Foundation\Bus\PendingDispatch;
 use Illuminate\Support\Str;
 use Spatie\WebhookServer\BackoffStrategy\BackoffStrategy;
 use Spatie\WebhookServer\Exceptions\CouldNotCallWebhook;
@@ -176,18 +177,18 @@ class WebhookCall
         return $this;
     }
 
-    public function dispatch(): void
+    public function dispatch(): PendingDispatch
     {
         $this->prepareForDispatch();
 
-        dispatch($this->callWebhookJob);
+        return dispatch($this->callWebhookJob);
     }
 
-    public function dispatchNow(): void
+    public function dispatchNow()
     {
         $this->prepareForDispatch();
 
-        dispatch_now($this->callWebhookJob);
+        return dispatch_now($this->callWebhookJob);
     }
 
     protected function prepareForDispatch(): void


### PR DESCRIPTION
When dispatching a job within a database transaction, it is possible that the job will be processed by a worker before the transaction has committed. When this happens, any updates you have made to models or database records during the database transaction may not yet be reflected in the database. So returning the return value of `dispatch()` helper will help us to call `->afterCommit();` like mentioned in [Laravel documents here](https://laravel.com/docs/8.x/queues#specifying-commit-dispatch-behavior-inline).