### PR TITLE
Add dispatchSync method

### DIFF
--- a/src/WebhookCall.php
+++ b/src/WebhookCall.php
@@ -191,6 +191,18 @@ class WebhookCall
         return dispatch_now($this->callWebhookJob);
     }
 
+    public function dispatchSync(): void
+    {
+        if (function_exists('dispatch_sync')) {
+            $this->prepareForDispatch();
+
+            dispatch_sync($this->callWebhookJob);
+            return;
+        }
+
+        $this->dispatchNow();
+    }
+
     protected function prepareForDispatch(): void
     {
         if (! $this->callWebhookJob->webhookUrl) {

--- a/tests/CallWebhookJobTest.php
+++ b/tests/CallWebhookJobTest.php
@@ -43,9 +43,19 @@ class CallWebhookJobTest extends TestCase
     }
 
     /** @test */
-    public function it_can_make_a_synchronous_webhook_call()
+    public function it_can_make_a_legacy_synchronous_webhook_call()
     {
         $this->baseWebhook()->dispatchNow();
+
+        $this
+            ->testClient
+            ->assertRequestsMade([$this->baseRequest()]);
+    }
+
+    /** @test */
+    public function it_can_make_a_synchronous_webhook_call()
+    {
+        $this->baseWebhook()->dispatchSync();
 
         $this
             ->testClient


### PR DESCRIPTION
The method `dispatch_now` was marked as deprecated and `dispatch_sync` was added in Laravel 8.36.

https://github.com/laravel/framework/pull/36835
https://github.com/laravel/framework/pull/36834

This adds a `dispatchSync` method that fallbacks to `dispatchNow` if an earlier Laravel version (6, 7, < 8.36) is being used by checking if the new `dispatch_sync` method exists or not.