### PR TITLE
Allow setting queue connection

### DIFF
--- a/config/webhook-server.php
+++ b/config/webhook-server.php
@@ -8,6 +8,11 @@ return [
     'queue' => 'default',
 
     /*
+     *  The default queue connection that should be used to send webhook requests.
+     */
+    'connection' => null,
+
+    /*
      * The default http verb to use.
      */
     'http_verb' => 'post',

--- a/src/WebhookCall.php
+++ b/src/WebhookCall.php
@@ -86,7 +86,7 @@ class WebhookCall
         return $this;
     }
 
-    public function onConnection(string $connection): self
+    public function onConnection(?string $connection): self
     {
         $this->callWebhookJob->connection = $connection;
 

--- a/src/WebhookCall.php
+++ b/src/WebhookCall.php
@@ -33,6 +33,7 @@ class WebhookCall
         return (new static())
             ->uuid(Str::uuid())
             ->onQueue($config['queue'])
+            ->onConnection($config['connection'] ?? null)
             ->useHttpVerb($config['http_verb'])
             ->maximumTries($config['tries'])
             ->useBackoffStrategy($config['backoff_strategy'])
@@ -81,6 +82,13 @@ class WebhookCall
     public function onQueue(string $queue): self
     {
         $this->callWebhookJob->queue = $queue;
+
+        return $this;
+    }
+
+    public function onConnection(string $connection): self
+    {
+        $this->callWebhookJob->connection = $connection;
 
         return $this;
     }

--- a/tests/WebhookTest.php
+++ b/tests/WebhookTest.php
@@ -85,6 +85,24 @@ class WebhookTest extends TestCase
     }
 
     /** @test */
+    public function it_can_override_default_queue_connection()
+    {
+        $url = 'https://localhost';
+
+        WebhookCall::create()->url($url)
+            ->onConnection('foo')
+            ->useSecret('123')
+            ->dispatch()
+        ;
+
+        Queue::assertPushed(CallWebhookJob::class, function (CallWebhookJob $job) use ($url) {
+            $this->assertEquals('foo', $job->connection);
+
+            return true;
+        });
+    }
+
+    /** @test */
     public function it_will_throw_an_exception_when_calling_a_webhook_without_proving_an_url()
     {
         $this->expectException(CouldNotCallWebhook::class);


### PR DESCRIPTION
First of all huge thank you for this package!

With that out of the way, i noticed the package lacked support for setting the queue connection on the WebhookCall class.

I do however know i can call the `onConnection` method on the return value of dispatch sense it's just a `PendingDispatch` object. But I do believe we need to be consistent and sense we already have a `onQueue` method on the `WebhookCall` class I thought it would be nice to also expose a `onConnection` on the `WebhookCall` class.


