### PR TITLE
Add ability to use default queue of connection

### DIFF
--- a/src/CallWebhookJob.php
+++ b/src/CallWebhookJob.php
@@ -38,8 +38,8 @@ class CallWebhookJob implements ShouldQueue
 
     public bool $verifySsl;
 
-    /** @var string */
-    public $queue;
+    /** @var string|null */
+    public $queue = null;
 
     public array $payload = [];
 

--- a/src/WebhookCall.php
+++ b/src/WebhookCall.php
@@ -79,7 +79,7 @@ class WebhookCall
         return $this->uuid;
     }
 
-    public function onQueue(string $queue): self
+    public function onQueue(?string $queue): self
     {
         $this->callWebhookJob->queue = $queue;
 


### PR DESCRIPTION
I want to use the default queue for the used queue connection.

For example, for the `database` connection this would be in the following config: `queue.connections.database.queue`

If the job has `$queue` set to `null` Laravel automatically uses the default queue of the connection.
It is currently not possible to use this, because the type definitions forbid `null` values.