### PR TITLE
Feature Request: Support using webhook URLs as part of webhook signatures

### DIFF
--- a/src/Signer/DefaultSigner.php
+++ b/src/Signer/DefaultSigner.php
@@ -4,7 +4,7 @@ namespace Spatie\WebhookServer\Signer;
 
 class DefaultSigner implements Signer
 {
-    public function calculateSignature(array $payload, string $secret): string
+    public function calculateSignature(string $webhookUrl, array $payload, string $secret): string
     {
         $payloadJson = json_encode($payload);
 

--- a/src/Signer/Signer.php
+++ b/src/Signer/Signer.php
@@ -6,5 +6,5 @@ interface Signer
 {
     public function signatureHeaderName(): string;
 
-    public function calculateSignature(array $payload, string $secret): string;
+    public function calculateSignature(string $webhookUrl, array $payload, string $secret): string;
 }

--- a/src/WebhookCall.php
+++ b/src/WebhookCall.php
@@ -220,7 +220,7 @@ class WebhookCall
             return $headers;
         }
 
-        $signature = $this->signer->calculateSignature($this->payload, $this->secret);
+        $signature = $this->signer->calculateSignature($this->callWebhookJob->webhookUrl, $this->payload, $this->secret);
 
         $headers[$this->signer->signatureHeaderName()] = $signature;
 

--- a/tests/DefaultSignerTest.php
+++ b/tests/DefaultSignerTest.php
@@ -11,7 +11,7 @@ class DefaultSignerTest extends TestCase
     {
         $signer = new DefaultSigner();
 
-        $signature = $signer->calculateSignature(['a' => '1'], 'abc');
+        $signature = $signer->calculateSignature('https://my.app/webhooks', ['a' => '1'], 'abc');
 
         $this->assertEquals(
             '345611a3626cf5e080a7a412184001882ab231b8bdb465dc76dbf709f01f210a',


### PR DESCRIPTION
We have a use-case where the signature header need to take the subscriber's URL into account. Unfortunately, the current `Signer` interface does not pass along the webhook URL.

This takes the most obvious approach of simply adding the URL as an arg to the `Signer#calculateSignature()`. The drawback is it's a BC-breaking change. Thought about passing in `WebhookCall` to potentially minimize future BC-breaking changes, but I feel that is giving the signer too much information _and_ control, since that object is mutable.

Thoughts?