### PR TITLE
add string payload

### DIFF
--- a/src/CallWebhookJob.php
+++ b/src/CallWebhookJob.php
@@ -112,7 +112,7 @@ class CallWebhookJob implements ShouldQueue
         if ($lastAttempt) {
             $this->dispatchEvent(FinalWebhookCallFailedEvent::class);
 
-            $this->delete();
+            $this->fail();
         }
     }
 

--- a/src/CallWebhookJob.php
+++ b/src/CallWebhookJob.php
@@ -112,7 +112,7 @@ class CallWebhookJob implements ShouldQueue
         if ($lastAttempt) {
             $this->dispatchEvent(FinalWebhookCallFailedEvent::class);
 
-            $this->fail();
+            $this->delete();
         }
     }
 

--- a/src/CallWebhookJob.php
+++ b/src/CallWebhookJob.php
@@ -41,7 +41,7 @@ class CallWebhookJob implements ShouldQueue
     /** @var string|null */
     public $queue = null;
 
-    public array $payload = [];
+    public array|string $payload = [];
 
     public array $meta = [];
 
@@ -67,7 +67,7 @@ class CallWebhookJob implements ShouldQueue
         try {
             $body = strtoupper($this->httpVerb) === 'GET'
                 ? ['query' => $this->payload]
-                : ['body' => json_encode($this->payload)];
+                : ['body' => is_array($this->payload) ? json_encode($this->payload) : $this->payload];
 
             $this->response = $client->request($this->httpVerb, $this->webhookUrl, array_merge([
                 'timeout' => $this->requestTimeout,

--- a/src/Events/WebhookCallEvent.php
+++ b/src/Events/WebhookCallEvent.php
@@ -10,7 +10,7 @@ abstract class WebhookCallEvent
     public function __construct(
         public string $httpVerb,
         public string $webhookUrl,
-        public array $payload,
+        public array|string $payload,
         public array $headers,
         public array $meta,
         public array $tags,

--- a/src/Exceptions/CouldNotCallWebhook.php
+++ b/src/Exceptions/CouldNotCallWebhook.php
@@ -15,9 +15,4 @@ class CouldNotCallWebhook extends Exception
     {
         return new static('Could not call the webhook because no secret has been set.');
     }
-
-    public static function secretNotAllowed(): self
-    {
-        return new static('Could not call the webhook because secret is not allowed for GET method.');
-    }
 }

--- a/src/Exceptions/CouldNotCallWebhook.php
+++ b/src/Exceptions/CouldNotCallWebhook.php
@@ -15,4 +15,9 @@ class CouldNotCallWebhook extends Exception
     {
         return new static('Could not call the webhook because no secret has been set.');
     }
+
+    public static function secretNotAllowed(): self
+    {
+        return new static('Could not call the webhook because secret is not allowed for GET method.');
+    }
 }

--- a/src/Signer/DefaultSigner.php
+++ b/src/Signer/DefaultSigner.php
@@ -4,11 +4,9 @@ namespace Spatie\WebhookServer\Signer;
 
 class DefaultSigner implements Signer
 {
-    public function calculateSignature(string $webhookUrl, array $payload, string $secret): string
+    public function calculateSignature(string $webhookUrl, string $payload, string $secret): string
     {
-        $payloadJson = json_encode($payload);
-
-        return hash_hmac('sha256', $payloadJson, $secret);
+        return hash_hmac('sha256', $payload, $secret);
     }
 
     public function signatureHeaderName(): string

--- a/src/Signer/Signer.php
+++ b/src/Signer/Signer.php
@@ -6,5 +6,5 @@ interface Signer
 {
     public function signatureHeaderName(): string;
 
-    public function calculateSignature(string $webhookUrl, array $payload, string $secret): string;
+    public function calculateSignature(string $webhookUrl, string $payload, string $secret): string;
 }

--- a/src/WebhookCall.php
+++ b/src/WebhookCall.php
@@ -205,10 +205,6 @@ class WebhookCall
             throw CouldNotCallWebhook::secretNotSet();
         }
 
-        if ($this->signWebhook && strtoupper($this->callWebhookJob->httpVerb) === 'GET') {
-            throw CouldNotCallWebhook::secretNotAllowed();
-        }
-
         $this->callWebhookJob->headers = $this->getAllHeaders();
     }
 

--- a/tests/CallWebhookJobTest.php
+++ b/tests/CallWebhookJobTest.php
@@ -43,6 +43,18 @@ class CallWebhookJobTest extends TestCase
     }
 
     /** @test */
+    public function it_can_make_a_webhook_with_string_payload_call()
+    {
+        $this->baseWebhook()->payload(json_encode(['a' => 1]))->dispatch();
+
+        $this->artisan('queue:work --once');
+
+        $this
+            ->testClient
+            ->assertRequestsMade([$this->baseRequest()]);
+    }
+
+    /** @test */
     public function it_can_make_a_legacy_synchronous_webhook_call()
     {
         $this->baseWebhook()->dispatchSync();

--- a/tests/DefaultSignerTest.php
+++ b/tests/DefaultSignerTest.php
@@ -11,7 +11,7 @@ class DefaultSignerTest extends TestCase
     {
         $signer = new DefaultSigner();
 
-        $signature = $signer->calculateSignature('https://my.app/webhooks', ['a' => '1'], 'abc');
+        $signature = $signer->calculateSignature('https://my.app/webhooks', json_encode(['a' => '1']), 'abc');
 
         $this->assertEquals(
             '345611a3626cf5e080a7a412184001882ab231b8bdb465dc76dbf709f01f210a',


### PR DESCRIPTION
- currently, it's only possible to use the payload with an array which is sent in json format, my pull request adds support for the type string payload
- tests : ✔
- add a new test : ✔
- Yes, I changed an interface, but define to conversation from an array to a json string is not logical in a signer interface. What do you think ?