### PR TITLE
add option "failed if error"

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,6 @@ return [
     'queue' => 'default',
 
     /*
-     *  The default queue connection that should be used to send webhook requests.
-     */
-    'connection' => null,
-
-    /*
      * The default http verb to use.
      */
     'http_verb' => 'post',
@@ -66,9 +61,7 @@ return [
     /*
      * These are the headers that will be added to all webhook requests.
      */
-    'headers' => [
-        'Content-Type' => 'application/json',
-    ],
+    'headers' => [],
 
     /*
      * If a call to a webhook takes longer that this amount of seconds
@@ -91,18 +84,6 @@ return [
      * of the webhook is valid.
      */
     'verify_ssl' => true,
-
-    /*
-     * By default no job becomes failed if Exception thrown.
-     * If true, failed jobs are added to `failed_job` database table and it's possible to retry these jobs later.
-     */
-    'failed_if_exception' => false,
-
-    /*
-     * When using Laravel Horizon you can specify tags that should be used on the
-     * underlying job that performs the webhook request.
-     */
-    'tags' => [],
 ];
 ```
 
@@ -308,15 +289,14 @@ By default, the package will not log any exceptions that are thrown when sending
 To handle exceptions you need to create listeners for the `Spatie\WebhookServer\Events\WebhookCallFailedEvent` and/or `Spatie\WebhookServer\Events\FinalWebhookCallFailedEvent` events.
 
 #### Retry failed execution
-You can activate the `failed_if_exception` option of the `webhook-server` config file. Alternatively, you can activate the fail job if Exception on a specific webhook like this:
-
+By default, failing jobs will be ignored. To throw an exception when the last attempt of a job fails, you can call `throwExceptionOnFailure` :
 ```php
 WebhookCall::create()
-    ->failedIfException()
+    ->throwExceptionOnFailure()
     ...
     ->dispatch();
 ```
-This option add a webhook to laravel `failed_jobs` database table if an exception occurs during execution. You can retry this execution with `php artisan queue:retry {jobId}` [Laravel doc to retry a job](https://laravel.com/docs/queues#retrying-failed-jobs).
+or activate the `throw_exception_on_failure` global option of the `webhook-server` config file.
 
 ### Events
 

--- a/config/webhook-server.php
+++ b/config/webhook-server.php
@@ -59,10 +59,9 @@ return [
     'verify_ssl' => true,
 
     /*
-     * By default no job becomes failed if Exception thrown.
-     * If true, failed jobs are added to `failed_job` database table and it's possible to retry these jobs later.
+     * When set to true, an exception will be thrown when the last attempt fails
      */
-    'failed_if_exception' => false,
+    'throw_exception_on_failure' => false,
 
     /*
      * When using Laravel Horizon you can specify tags that should be used on the

--- a/src/CallWebhookJob.php
+++ b/src/CallWebhookJob.php
@@ -38,7 +38,7 @@ class CallWebhookJob implements ShouldQueue
 
     public bool $verifySsl;
 
-    public bool $failedIfException;
+    public bool $throwExceptionOnFailure;
 
     /** @var string|null */
     public $queue = null;
@@ -113,7 +113,7 @@ class CallWebhookJob implements ShouldQueue
             if ($lastAttempt) {
                 $this->dispatchEvent(FinalWebhookCallFailedEvent::class);
 
-                $this->failedIfException ? $this->fail() : $this->delete();
+                $this->throwExceptionOnFailure ? $this->fail() : $this->delete();
             }
         }
     }

--- a/src/WebhookCall.php
+++ b/src/WebhookCall.php
@@ -42,7 +42,7 @@ class WebhookCall
             ->withHeaders($config['headers'])
             ->withTags($config['tags'])
             ->verifySsl($config['verify_ssl'])
-            ->failedIfException($config['failed_if_exception']);
+            ->throwExceptionOnFailure($config['throw_exception_on_failure']);
     }
 
     public function __construct()
@@ -172,9 +172,9 @@ class WebhookCall
         return $this;
     }
 
-    public function failedIfException(bool $failedIfException = true): self
+    public function throwExceptionOnFailure(bool $throwExceptionOnFailure = true): self
     {
-        $this->callWebhookJob->failedIfException = $failedIfException;
+        $this->callWebhookJob->throwExceptionOnFailure = $throwExceptionOnFailure;
 
         return $this;
     }

--- a/tests/CallWebhookJobTest.php
+++ b/tests/CallWebhookJobTest.php
@@ -229,15 +229,15 @@ class CallWebhookJobTest extends TestCase
     }
 
     /** @test */
-    public function it_s_generate_job_failed_event_if_an_exception_throws_and_failed_if_exception_config_is_set()
+    public function it_s_generate_job_failed_event_if_an_exception_throws_and_throw_exception_on_failure_config_is_set()
     {
         $this->testClient->throwConnectionException();
 
-        $this->baseWebhook()->maximumTries(1)->failedIfException()->dispatch();
+        $this->baseWebhook()->maximumTries(1)->throwExceptionOnFailure()->dispatch();
 
         $this->artisan('queue:work --once');
 
-        Event::assertDispatched(JobFailed::class, 1);
+        Event::assertDispatched(JobFailed::class);
     }
 
     protected function baseWebhook(): WebhookCall

--- a/tests/WebhookTest.php
+++ b/tests/WebhookTest.php
@@ -36,7 +36,7 @@ class WebhookTest extends TestCase
             $this->assertEquals($config['backoff_strategy'], $job->backoffStrategyClass);
             $this->assertContains($config['signature_header_name'], array_keys($job->headers));
             $this->assertEquals($config['verify_ssl'], $job->verifySsl);
-            $this->assertEquals($config['failed_if_exception'], $job->failedIfException);
+            $this->assertEquals($config['throw_exception_on_failure'], $job->throwExceptionOnFailure);
             $this->assertEquals($config['tags'], $job->tags);
 
             return true;


### PR DESCRIPTION
Add an option to fail the job if execution error (to be able to restart the execution later https://laravel.com/docs/8.x/queues#retrying-failed-jobs )

I failed to write a test to validate that a job failed.