### PR TITLE
Include Exception with Laravel queue failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
+.idea
 build
 composer.lock
 docs
 vendor
 coverage
 .php-cs-fixer.cache
+.phpunit.result.cache

--- a/src/CallWebhookJob.php
+++ b/src/CallWebhookJob.php
@@ -113,7 +113,7 @@ class CallWebhookJob implements ShouldQueue
             if ($lastAttempt) {
                 $this->dispatchEvent(FinalWebhookCallFailedEvent::class);
 
-                $this->throwExceptionOnFailure ? $this->fail() : $this->delete();
+                $this->throwExceptionOnFailure ? $this->fail($exception) : $this->delete();
             }
         }
     }

--- a/tests/CallWebhookJobTest.php
+++ b/tests/CallWebhookJobTest.php
@@ -3,6 +3,7 @@
 namespace Spatie\WebhookServer\Tests;
 
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\TransferStats;
 use Illuminate\Queue\Events\JobFailed;
 use Illuminate\Support\Facades\Event;
@@ -237,7 +238,11 @@ class CallWebhookJobTest extends TestCase
 
         $this->artisan('queue:work --once');
 
-        Event::assertDispatched(JobFailed::class);
+        Event::assertDispatched(JobFailed::class, function (JobFailed $event) {
+            $this->assertInstanceOf(ConnectException::class, $event->exception);
+
+            return true;
+        });
     }
 
     protected function baseWebhook(): WebhookCall


### PR DESCRIPTION
Without providing the exception, Laravel will simply throw a `Illuminate\Queue\ManuallyFailedException`. This allows the real Exception to be logged with the failed job for better debugging.