### PR TITLE
Allow sub-classes of `CallWebhookJob` to use a `GuzzleHttp\Client` specific for outgoing webhooks

### DIFF
--- a/src/CallWebhookJob.php
+++ b/src/CallWebhookJob.php
@@ -61,8 +61,7 @@ class CallWebhookJob implements ShouldQueue
 
     public function handle()
     {
-        /** @var \GuzzleHttp\Client $client */
-        $client = app(Client::class);
+        $client = $this->getClient();
 
         $lastAttempt = $this->attempts() >= $this->tries;
 
@@ -126,6 +125,11 @@ class CallWebhookJob implements ShouldQueue
     public function getResponse(): ?Response
     {
         return $this->response;
+    }
+
+    protected function getClient(): Client
+    {
+        return app(Client::class);
     }
 
     private function dispatchEvent(string $eventClass)


### PR DESCRIPTION
At work, due to infrastructure reasons, outgoing web-hook notifications needs to meet some requirements. Those requirements can be satisfied by a `GuzzleHttp\Client` instance configured w/ the right options/middle-wares.

This change would allow our `CallWebhookJob` sub-class to specify the properly-configured client to use for webhooks.