### PR TITLE
Add option for configurable Webhook Job

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,11 @@ return [
      * This class determines how many seconds there should be between attempts.
      */
     'backoff_strategy' => \Spatie\WebhookServer\BackoffStrategy\ExponentialBackoffStrategy::class,
+        
+    /*
+     * This class is used to dispatch webhooks on to the queue.
+     */
+    'webhook_job' => \Spatie\WebhookServer\CallWebhookJob::class,
 
     /*
      * By default we will verify that the ssl certificate of the destination

--- a/config/webhook-server.php
+++ b/config/webhook-server.php
@@ -53,6 +53,11 @@ return [
     'backoff_strategy' => \Spatie\WebhookServer\BackoffStrategy\ExponentialBackoffStrategy::class,
 
     /*
+     * This class is used to dispatch webhooks on to the queue.
+     */
+    'webhook_job' => \Spatie\WebhookServer\CallWebhookJob::class,
+
+    /*
      * By default we will verify that the ssl certificate of the destination
      * of the webhook is valid.
      */

--- a/src/CallWebhookJob.php
+++ b/src/CallWebhookJob.php
@@ -110,7 +110,7 @@ class CallWebhookJob implements ShouldQueue
 
             $this->dispatchEvent(WebhookCallFailedEvent::class);
 
-            if ($lastAttempt) {
+            if ($lastAttempt || $this->shouldBeRemovedFromQueue()) {
                 $this->dispatchEvent(FinalWebhookCallFailedEvent::class);
 
                 $this->throwExceptionOnFailure ? $this->fail($exception) : $this->delete();
@@ -149,5 +149,10 @@ class CallWebhookJob implements ShouldQueue
             $this->uuid,
             $this->transferStats
         ));
+    }
+
+    private function shouldBeRemovedFromQueue(): bool
+    {
+        return false;
     }
 }

--- a/src/Exceptions/InvalidWebhookJob.php
+++ b/src/Exceptions/InvalidWebhookJob.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Spatie\WebhookServer\Exceptions;
+
+use Exception;
+use Spatie\WebhookServer\CallWebhookJob;
+
+class InvalidWebhookJob extends Exception
+{
+    public static function doesNotExtendCallWebhookJob(string $invalidWebhookJobClass): self
+    {
+        $callWebhookJob = CallWebhookJob::class;
+
+        return new static("`{$invalidWebhookJobClass}` is not a valid webhook job class because it does not extend `$callWebhookJob`");
+    }
+}

--- a/tests/WebhookTest.php
+++ b/tests/WebhookTest.php
@@ -7,6 +7,7 @@ use Spatie\WebhookServer\CallWebhookJob;
 use Spatie\WebhookServer\Exceptions\CouldNotCallWebhook;
 use Spatie\WebhookServer\Exceptions\InvalidBackoffStrategy;
 use Spatie\WebhookServer\Exceptions\InvalidSigner;
+use Spatie\WebhookServer\Exceptions\InvalidWebhookJob;
 use Spatie\WebhookServer\WebhookCall;
 
 class WebhookTest extends TestCase
@@ -141,6 +142,14 @@ class WebhookTest extends TestCase
         $this->expectException(InvalidSigner::class);
 
         WebhookCall::create()->signUsing(static::class);
+    }
+
+    /** @test */
+    public function it_will_throw_an_exception_when_using_an_invalid_webhook_job()
+    {
+        $this->expectException(InvalidWebhookJob::class);
+
+        WebhookCall::create()->useJob(static::class);
     }
 
     /** @test */


### PR DESCRIPTION
This pull request adds the option for users to extend and override the `CallWebhookJob`.

This was suggested by @freekmurze as it's a better option to provide the most flexibility when it comes to custom behaviour of the method `shouldRemoveFromQueue()`.

See here: https://github.com/spatie/laravel-webhook-server/pull/133#issuecomment-1304855149