### PR TITLE
Change to protected properties `$response`, `$errorType` and `$errorMessage` in `CallWebhookJob` 

### DIFF
--- a/src/CallWebhookJob.php
+++ b/src/CallWebhookJob.php
@@ -54,11 +54,11 @@ class CallWebhookJob implements ShouldQueue
 
     public string $uuid = '';
 
-    private ?Response $response = null;
+    protected ?Response $response = null;
 
-    private ?string $errorType = null;
+    protected ?string $errorType = null;
 
-    private ?string $errorMessage = null;
+    protected ?string $errorMessage = null;
 
     private ?TransferStats $transferStats = null;
 


### PR DESCRIPTION
In PR #135 the option was added to extend or override the `CallWebhookJob` by changing the value of the configuration key `webhook_job` to use an extending class.

The idea behind this was to give user the ability to let the job fail on certain criterias like response codes or custom behaviour by overriding the `shouldBeRemovedFromQueue()` method.

Today I've noticed that it slipped my mind that the response, error type and error message are not available to the extending class because the parent class has the properties set to private.

This PR changes them to protected.