### PR TITLE
Webhook option to allow sending a raw body instead of array -> json.

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,19 @@ WebhookCall::create()
 ```
 or activate the `throw_exception_on_failure` global option of the `webhook-server` config file.
 
+### Sending raw string body instead of JSON
+
+By default, all webhooks will transform the payload into JSON. Instead of sending JSON, you can send any string by using the `sendRawBody(string $body)` option instead.
+
+Due to type mismatch in the Signer API, it is currently not support to sign raw data requests
+```php
+WebhookCall::create()
+    ->sendRawBody("<root>someXMLContent</root>")
+    ->doNotSign()
+    ...
+    ->dispatch();
+```
+
 ### Events
 
 The package fires these events:

--- a/src/CallWebhookJob.php
+++ b/src/CallWebhookJob.php
@@ -46,13 +46,15 @@ class CallWebhookJob implements ShouldQueue
     /** @var string|null */
     public $queue = null;
 
-    public array $payload = [];
+    public array|string $payload = [];
 
     public array $meta = [];
 
     public array $tags = [];
 
     public string $uuid = '';
+
+    public string $outputType = "JSON";
 
     protected ?Response $response = null;
 
@@ -69,7 +71,7 @@ class CallWebhookJob implements ShouldQueue
         try {
             $body = strtoupper($this->httpVerb) === 'GET'
                 ? ['query' => $this->payload]
-                : ['body' => json_encode($this->payload)];
+                : ['body' => $this->generateBody()];
 
             $this->response = $this->createRequest($body);
 
@@ -161,5 +163,13 @@ class CallWebhookJob implements ShouldQueue
             $this->uuid,
             $this->transferStats
         ));
+    }
+
+    private function generateBody(): string
+    {
+        return match ($this->outputType) {
+            "RAW" => $this->payload,
+            default => json_encode($this->payload),
+        };
     }
 }

--- a/src/WebhookCall.php
+++ b/src/WebhookCall.php
@@ -25,7 +25,6 @@ class WebhookCall
 
     private array $payload = [];
 
-    private string $rawBody;
     private $signWebhook = true;
 
     public static function create(): self

--- a/src/WebhookCall.php
+++ b/src/WebhookCall.php
@@ -25,6 +25,7 @@ class WebhookCall
 
     private array $payload = [];
 
+    private string $rawBody;
     private $signWebhook = true;
 
     public static function create(): self
@@ -253,6 +254,14 @@ class WebhookCall
     public function dispatchSyncUnless($condition): void
     {
         $this->dispatchSyncIf(! $condition);
+    }
+
+    public function sendRawBody(string $body): self
+    {
+        $this->callWebhookJob->payload = $body;
+        $this->callWebhookJob->outputType = "RAW";
+
+        return $this;
     }
 
     protected function prepareForDispatch(): void

--- a/tests/CallWebhookJobTest.php
+++ b/tests/CallWebhookJobTest.php
@@ -300,3 +300,24 @@ it('generate job failed event if an exception throws and throw exception on fail
         return true;
     });
 });
+
+it('send raw body data if rawBody is set', function () {
+    $testBody = "<xml>anotherOption</xml>";
+    WebhookCall::create()
+        ->url('https://example.com/webhooks')
+        ->useSecret('abc')
+        ->sendRawBody($testBody)
+        ->doNotSign()
+        ->dispatch();
+
+    $baseRequest = baseRequest();
+
+    $baseRequest['options']['body'] = $testBody;
+    unset($baseRequest['options']['headers']['Signature']);
+
+    artisan('queue:work --once');
+
+    $this
+        ->testClient
+        ->assertRequestsMade([$baseRequest]);
+});


### PR DESCRIPTION
Allow people to send non-array formats as raw body strings (xml, plain text, etc.)

Usage:
```    
WebhookCall::create()
        ->sendRawBody("<root>someXMLExample</root>")
        ->doNotSign()
        ...
        ->dispatch();
```

Cannot be combined with signing at this moment since the Signer function expects an array, so use `doNotSign()` with this functionality.
To support this we'd need to allow the Signer to accept a mixed (or at least array|string) input for payload. I tested that and it will work fine actually. Let me know if that's a good solution and I'll add that.

[x] Tests succeed
[x] Readme updated