### PR TITLE
Fix webhook event type for raw body

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,7 +352,8 @@ or activate the `throw_exception_on_failure` global option of the `webhook-serve
 
 By default, all webhooks will transform the payload into JSON. Instead of sending JSON, you can send any string by using the `sendRawBody(string $body)` option instead.
 
-Due to type mismatch in the Signer API, it is currently not support to sign raw data requests
+Due to type mismatch in the Signer API, it is currently not support to sign raw data requests.
+When using the _sendRawBody_ option, you will receive a _string_ payload in the WebhookEvents.
 ```php
 WebhookCall::create()
     ->sendRawBody("<root>someXMLContent</root>")

--- a/src/Events/WebhookCallEvent.php
+++ b/src/Events/WebhookCallEvent.php
@@ -10,7 +10,7 @@ abstract class WebhookCallEvent
     public function __construct(
         public string $httpVerb,
         public string $webhookUrl,
-        public array $payload,
+        public array|string $payload,
         public array $headers,
         public array $meta,
         public array $tags,


### PR DESCRIPTION
Using the sendRawBody would cause events not to be dispatched due to a type conflict.
I've updated the type to a mixed array|string type and added an additional test case to check that events are indeed sent.

This should not affect any existing APIs.