### PR TITLE
Adds support for mutual TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,23 @@ WebhookCall::create()
     ...
 ```
 
+### Using mutual TLS authentication
+
+To safeguard the integrity of webhook data transmission, it's critical to authenticate the intended recipient of your webhook payload. 
+Mutual TLS authentication serves as a robust method for this purpose. Contrary to standard TLS, where only the client verifies the server, 
+mutual TLS requires both the webhook endpoint (acting as the client) and the webhook provider (acting as the server) to authenticate each other. 
+This is achieved through an exchange of certificates during the TLS handshake, ensuring that both parties confirm each other's identity.
+
+```php
+WebhookCall::create()
+    ->mutualTls(
+        certPath: storage_path('path/to/cert.pem'), 
+        certPassphrase: 'optional_cert_passphrase', 
+        sslKeyPath: storage_path('path/to/key.pem'), 
+        sslKeyPassphrase: 'optional_key_passphrase'
+    )
+```
+
 The proxy specification follows the [guzzlehttp proxy format](https://docs.guzzlephp.org/en/stable/request-options.html#proxy)
 
 ### Verifying the SSL certificate of the receiving app

--- a/README.md
+++ b/README.md
@@ -299,6 +299,8 @@ Mutual TLS authentication serves as a robust method for this purpose. Contrary t
 mutual TLS requires both the webhook endpoint (acting as the client) and the webhook provider (acting as the server) to authenticate each other. 
 This is achieved through an exchange of certificates during the TLS handshake, ensuring that both parties confirm each other's identity.
 
+> Note: If you need to include your own certificate authority, pass the certificate path to the `verifySsl()` method.
+
 ```php
 WebhookCall::create()
     ->mutualTls(

--- a/src/CallWebhookJob.php
+++ b/src/CallWebhookJob.php
@@ -35,11 +35,11 @@ class CallWebhookJob implements ShouldQueue
 
     public ?string $cert = null;
 
-    public ?string $certPassword = null;
+    public ?string $certPassphrase = null;
 
     public ?string $sslKey = null;
 
-    public ?string $sslKeyPassword = null;
+    public ?string $sslKeyPassphrase = null;
 
     public string $backoffStrategyClass;
 
@@ -151,8 +151,8 @@ class CallWebhookJob implements ShouldQueue
         ],
             $body,
             is_null($this->proxy) ? [] : ['proxy' => $this->proxy],
-            is_null($this->cert) ? [] : ['cert' => [$this->cert, $this->certPassword]],
-            is_null($this->sslKey) ? [] : ['ssl_key' => [$this->sslKey, $this->sslKeyPassword]]
+            is_null($this->cert) ? [] : ['cert' => [$this->cert, $this->certPassphrase]],
+            is_null($this->sslKey) ? [] : ['ssl_key' => [$this->sslKey, $this->sslKeyPassphrase]]
         ));
     }
 

--- a/src/CallWebhookJob.php
+++ b/src/CallWebhookJob.php
@@ -33,6 +33,14 @@ class CallWebhookJob implements ShouldQueue
 
     public int $requestTimeout;
 
+    public ?string $cert = null;
+
+    public ?string $certPassword = null;
+
+    public ?string $sslKey = null;
+
+    public ?string $sslKeyPassword = null;
+
     public string $backoffStrategyClass;
 
     public ?string $signerClass = null;
@@ -132,14 +140,20 @@ class CallWebhookJob implements ShouldQueue
     {
         $client = $this->getClient();
 
-        return $client->request($this->httpVerb, $this->webhookUrl, array_merge([
+        return $client->request($this->httpVerb, $this->webhookUrl, array_merge(
+            [
             'timeout' => $this->requestTimeout,
             'verify' => $this->verifySsl,
             'headers' => $this->headers,
             'on_stats' => function (TransferStats $stats) {
                 $this->transferStats = $stats;
             },
-        ], $body, is_null($this->proxy) ? [] : ['proxy' => $this->proxy]));
+        ],
+            $body,
+            is_null($this->proxy) ? [] : ['proxy' => $this->proxy],
+            is_null($this->cert) ? [] : ['cert' => [$this->cert, $this->certPassword]],
+            is_null($this->sslKey) ? [] : ['ssl_key' => [$this->sslKey, $this->sslKeyPassword]]
+        ));
     }
 
     protected function shouldBeRemovedFromQueue(): bool

--- a/src/CallWebhookJob.php
+++ b/src/CallWebhookJob.php
@@ -47,7 +47,7 @@ class CallWebhookJob implements ShouldQueue
 
     public array $headers = [];
 
-    public bool $verifySsl;
+    public string|bool $verifySsl;
 
     public bool $throwExceptionOnFailure;
 

--- a/src/WebhookCall.php
+++ b/src/WebhookCall.php
@@ -117,12 +117,12 @@ class WebhookCall
         return $this;
     }
 
-    public function mutualTls(string $cert, string $sslKey, ?string $certPassword = null, ?string $sslKeyPassword = null): self
+    public function mutualTls(string $certPath, string $sslKeyPath, ?string $certPassphrase = null, ?string $sslKeyPassphrase = null): self
     {
-        $this->callWebhookJob->cert = $cert;
-        $this->callWebhookJob->certPassword = $certPassword;
-        $this->callWebhookJob->sslKey = $sslKey;
-        $this->callWebhookJob->sslKeyPassword = $sslKeyPassword;
+        $this->callWebhookJob->cert = $certPath;
+        $this->callWebhookJob->certPassphrase = $certPassphrase;
+        $this->callWebhookJob->sslKey = $sslKeyPath;
+        $this->callWebhookJob->sslKeyPassphrase = $sslKeyPassphrase;
 
         return $this;
     }

--- a/src/WebhookCall.php
+++ b/src/WebhookCall.php
@@ -170,7 +170,7 @@ class WebhookCall
         return $this;
     }
 
-    public function verifySsl(bool $verifySsl = true): self
+    public function verifySsl(bool|string $verifySsl = true): self
     {
         $this->callWebhookJob->verifySsl = $verifySsl;
 

--- a/src/WebhookCall.php
+++ b/src/WebhookCall.php
@@ -117,6 +117,16 @@ class WebhookCall
         return $this;
     }
 
+    public function mutualTls(string $cert, string $sslKey, ?string $certPassword = null, ?string $sslKeyPassword = null): self
+    {
+        $this->callWebhookJob->cert = $cert;
+        $this->callWebhookJob->certPassword = $certPassword;
+        $this->callWebhookJob->sslKey = $sslKey;
+        $this->callWebhookJob->sslKeyPassword = $sslKeyPassword;
+
+        return $this;
+    }
+
     public function useBackoffStrategy(string $backoffStrategyClass): self
     {
         if (! is_subclass_of($backoffStrategyClass, BackoffStrategy::class)) {

--- a/tests/CallWebhookJobTest.php
+++ b/tests/CallWebhookJobTest.php
@@ -184,6 +184,40 @@ it('can disable verifying SSL', function () {
         ->assertRequestsMade([$baseRequest]);
 });
 
+it('will use mutual TLS without passphrases', function () {
+    baseWebhook()
+        ->mutualTls('foobar', 'barfoo')
+        ->dispatch();
+
+    $baseRequest = baseRequest();
+
+    $baseRequest['options']['cert'] = ['foobar', null];
+    $baseRequest['options']['ssl_key'] = ['barfoo', null];
+
+    artisan('queue:work --once');
+
+    $this
+        ->testClient
+        ->assertRequestsMade([$baseRequest]);
+});
+
+it('will use mutual TLS with passphrases', function () {
+    baseWebhook()
+        ->mutualTls('foobar', 'barfoo', 'foobarpassword', 'barfoopassword')
+        ->dispatch();
+
+    $baseRequest = baseRequest();
+
+    $baseRequest['options']['cert'] = ['foobar', 'foobarpassword'];
+    $baseRequest['options']['ssl_key'] = ['barfoo', 'barfoopassword'];
+
+    artisan('queue:work --once');
+
+    $this
+        ->testClient
+        ->assertRequestsMade([$baseRequest]);
+});
+
 it('will use a proxy', function () {
     baseWebhook()
         ->useProxy('https://proxy.test')

--- a/tests/CallWebhookJobTest.php
+++ b/tests/CallWebhookJobTest.php
@@ -218,6 +218,25 @@ it('will use mutual TLS with passphrases', function () {
         ->assertRequestsMade([$baseRequest]);
 });
 
+it('will use mutual TLS with certificate authority', function () {
+    baseWebhook()
+        ->mutualTls('foobar', 'barfoo')
+        ->verifySsl('foofoo')
+        ->dispatch();
+
+    $baseRequest = baseRequest();
+
+    $baseRequest['options']['cert'] = ['foobar', null];
+    $baseRequest['options']['ssl_key'] = ['barfoo', null];
+    $baseRequest['options']['verify'] = 'foofoo';
+
+    artisan('queue:work --once');
+
+    $this
+        ->testClient
+        ->assertRequestsMade([$baseRequest]);
+});
+
 it('will use a proxy', function () {
     baseWebhook()
         ->useProxy('https://proxy.test')


### PR DESCRIPTION
The need for this PR arose out of our use of this package in a SaaS we are developing where we will pushing data via web hooks that is extremely sensitive in nature. We need to use all available options to ensure the integrity of our data and so we are requiring mutual TLS authentication. This PR adds support for mutual TLS that is already natively supported in Guzzle. 

A custom CA cert can be optionally passed to the `verifySsl` method.  The method now accepts booleans or strings to support cert paths.

**Implementation**:

```
WebhookCall::create()
  ->mutualTls(
    certPath: storage_path('path/to/cert.pem'), 
    certPassphrase: 'optional_cert_passphrase', 
    sslKeyPath: storage_path('path/to/key.pem'), 
    sslKeyPassphrase: 'optional_key_passphrase'
  )
  ->verifySsl(storage_path('path/to/ca.pem'))
  ->dispatch();
```