### PR TITLE
Add event that is being fired upon the webhook's dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ WebhookCall::create()
    ->dispatch();
 ```
 
-This will send a post request to `https://other-app.com/webhooks`. The body of the request will be JSON encoded version of the array passed to `payload`. The request will have a header called `Signature` that will contain a signature the receiving app can use [to verify](https://github.com/spatie/laravel-webhook-server#how-signing-requests-works) the payload hasn't been tampered with. Dispatching a webhook call will also fire a `WebhookCallDispatchedEvent`.
+This will send a post request to `https://other-app.com/webhooks`. The body of the request will be JSON encoded version of the array passed to `payload`. The request will have a header called `Signature` that will contain a signature the receiving app can use [to verify](https://github.com/spatie/laravel-webhook-server#how-signing-requests-works) the payload hasn't been tampered with. Dispatching a webhook call will also fire a `DispatchingWebhookCallEvent`.
 
 If the receiving app doesn't respond with a response code starting with `2`, the package will retry calling the webhook after 10 seconds. If that second attempt fails, the package will attempt to call the webhook a final time after 100 seconds. Should that attempt fail, the `FinalWebhookCallFailedEvent` will be raised.
 
@@ -384,9 +384,9 @@ WebhookCall::create()
 ### Events
 
 The package fires these events:
-- `WebhookCallDispatchedEvent`: the webhook call has been initially dispatched to the queue.
+- `DispatchingWebhookCallEvent`: right before the webhook call will be dispatched to the queue.
 - `WebhookCallSucceededEvent`: the remote app responded with a `2xx` response code.
-- `WebhookCallFailedEvent`: the remote app responded with a non `2xx` response code, or it did not respond at all
+- `WebhookCallFailedEvent`: the remote app responded with a non `2xx` response code, or it did not respond at all.
 - `FinalWebhookCallFailedEvent`: the final attempt to call the webhook failed.
 
 All these events have these properties:
@@ -399,7 +399,7 @@ All these events have these properties:
 - `tags`: the array of [tags](#adding-tags) used
 - `uuid`: a unique string to identify this call. This uuid will be the same for all attempts of a webhook call.
 
-Except for the `WebhookCallDispatchedEvent`, all events have these additional properties:
+Except for the `DispatchingWebhookCallEvent`, all events have these additional properties:
 
 - `attempt`: the attempt number
 - `response`: the response returned by the remote app. Can be an instance of `\GuzzleHttp\Psr7\Response` or `null`.

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ WebhookCall::create()
    ->dispatch();
 ```
 
-This will send a post request to `https://other-app.com/webhooks`. The body of the request will be JSON encoded version of the array passed to `payload`. The request will have a header called `Signature` that will contain a signature the receiving app can use [to verify](https://github.com/spatie/laravel-webhook-server#how-signing-requests-works) the payload hasn't been tampered with. 
+This will send a post request to `https://other-app.com/webhooks`. The body of the request will be JSON encoded version of the array passed to `payload`. The request will have a header called `Signature` that will contain a signature the receiving app can use [to verify](https://github.com/spatie/laravel-webhook-server#how-signing-requests-works) the payload hasn't been tampered with. Dispatching a webhook call will also fire a `WebhookCallDispatchedEvent`.
 
 If the receiving app doesn't respond with a response code starting with `2`, the package will retry calling the webhook after 10 seconds. If that second attempt fails, the package will attempt to call the webhook a final time after 100 seconds. Should that attempt fail, the `FinalWebhookCallFailedEvent` will be raised.
 
@@ -384,6 +384,7 @@ WebhookCall::create()
 ### Events
 
 The package fires these events:
+- `WebhookCallDispatchedEvent`: the webhook call has been initially dispatched to the queue.
 - `WebhookCallSucceededEvent`: the remote app responded with a `2xx` response code.
 - `WebhookCallFailedEvent`: the remote app responded with a non `2xx` response code, or it did not respond at all
 - `FinalWebhookCallFailedEvent`: the final attempt to call the webhook failed.
@@ -396,9 +397,12 @@ All these events have these properties:
 - `headers`: the headers that were sent. This array includes the signature header
 - `meta`: the array of values passed to the webhook with [the `meta` call](#adding-meta-information)
 - `tags`: the array of [tags](#adding-tags) used
+- `uuid`: a unique string to identify this call. This uuid will be the same for all attempts of a webhook call.
+
+Except for the `WebhookCallDispatchedEvent`, all events have these additional properties:
+
 - `attempt`: the attempt number
 - `response`: the response returned by the remote app. Can be an instance of `\GuzzleHttp\Psr7\Response` or `null`.
-- `uuid`: a unique string to identify this call. This uuid will be the same for all attempts of a webhook call.
 
 ## Testing
 

--- a/src/Events/DispatchingWebhookCallEvent.php
+++ b/src/Events/DispatchingWebhookCallEvent.php
@@ -2,7 +2,7 @@
 
 namespace Spatie\WebhookServer\Events;
 
-class WebhookCallDispatchedEvent
+class DispatchingWebhookCallEvent
 {
     public function __construct(
         public string $httpVerb,

--- a/src/Events/WebhookCallDispatchedEvent.php
+++ b/src/Events/WebhookCallDispatchedEvent.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Spatie\WebhookServer\Events;
+
+class WebhookCallDispatchedEvent
+{
+    public function __construct(
+        public string $httpVerb,
+        public string $webhookUrl,
+        public array|string $payload,
+        public array $headers,
+        public array $meta,
+        public array $tags,
+        public string $uuid,
+    ) {
+    }
+}

--- a/src/WebhookCall.php
+++ b/src/WebhookCall.php
@@ -5,7 +5,7 @@ namespace Spatie\WebhookServer;
 use Illuminate\Foundation\Bus\PendingDispatch;
 use Illuminate\Support\Str;
 use Spatie\WebhookServer\BackoffStrategy\BackoffStrategy;
-use Spatie\WebhookServer\Events\WebhookCallDispatchedEvent;
+use Spatie\WebhookServer\Events\DispatchingWebhookCallEvent;
 use Spatie\WebhookServer\Exceptions\CouldNotCallWebhook;
 use Spatie\WebhookServer\Exceptions\InvalidBackoffStrategy;
 use Spatie\WebhookServer\Exceptions\InvalidSigner;
@@ -230,7 +230,7 @@ class WebhookCall
     {
         $this->prepareForDispatch();
 
-        event(new WebhookCallDispatchedEvent(
+        event(new DispatchingWebhookCallEvent(
             $this->callWebhookJob->httpVerb,
             $this->callWebhookJob->webhookUrl,
             $this->callWebhookJob->payload,

--- a/src/WebhookCall.php
+++ b/src/WebhookCall.php
@@ -5,6 +5,7 @@ namespace Spatie\WebhookServer;
 use Illuminate\Foundation\Bus\PendingDispatch;
 use Illuminate\Support\Str;
 use Spatie\WebhookServer\BackoffStrategy\BackoffStrategy;
+use Spatie\WebhookServer\Events\WebhookCallDispatchedEvent;
 use Spatie\WebhookServer\Exceptions\CouldNotCallWebhook;
 use Spatie\WebhookServer\Exceptions\InvalidBackoffStrategy;
 use Spatie\WebhookServer\Exceptions\InvalidSigner;
@@ -228,6 +229,16 @@ class WebhookCall
     public function dispatch(): PendingDispatch
     {
         $this->prepareForDispatch();
+
+        event(new WebhookCallDispatchedEvent(
+            $this->callWebhookJob->httpVerb,
+            $this->callWebhookJob->webhookUrl,
+            $this->callWebhookJob->payload,
+            $this->callWebhookJob->headers,
+            $this->callWebhookJob->meta,
+            $this->callWebhookJob->tags,
+            $this->callWebhookJob->uuid,
+        ));
 
         return dispatch($this->callWebhookJob);
     }

--- a/tests/WebhookTest.php
+++ b/tests/WebhookTest.php
@@ -2,7 +2,7 @@
 
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Queue;
-use Spatie\WebhookServer\Events\WebhookCallDispatchedEvent;
+use Spatie\WebhookServer\Events\DispatchingWebhookCallEvent;
 use function PHPUnit\Framework\assertTrue;
 use Spatie\WebhookServer\CallWebhookJob;
 use Spatie\WebhookServer\Exceptions\CouldNotCallWebhook;
@@ -158,12 +158,12 @@ it('can dispatch a job that calls a webhook unless condition false', function ()
     Queue::assertPushed(CallWebhookJob::class);
 });
 
-it('will fire an event when a webhook is initially dispatched', function () {
+it('will fire an event right before the webhook is initially dispatched', function () {
     Event::fake();
 
     $url = 'https://localhost';
 
     WebhookCall::create()->url($url)->useSecret('123')->dispatchIf(true);
 
-    Event::assertDispatched(WebhookCallDispatchedEvent::class, 1);
+    Event::assertDispatched(DispatchingWebhookCallEvent::class, 1);
 });

--- a/tests/WebhookTest.php
+++ b/tests/WebhookTest.php
@@ -1,6 +1,8 @@
 <?php
 
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Queue;
+use Spatie\WebhookServer\Events\WebhookCallDispatchedEvent;
 use function PHPUnit\Framework\assertTrue;
 use Spatie\WebhookServer\CallWebhookJob;
 use Spatie\WebhookServer\Exceptions\CouldNotCallWebhook;
@@ -154,4 +156,14 @@ it('can dispatch a job that calls a webhook unless condition false', function ()
     WebhookCall::create()->url($url)->useSecret('123')->dispatchUnless(false);
 
     Queue::assertPushed(CallWebhookJob::class);
+});
+
+it('will fire an event when a webhook is initially dispatched', function () {
+    Event::fake();
+
+    $url = 'https://localhost';
+
+    WebhookCall::create()->url($url)->useSecret('123')->dispatchIf(true);
+
+    Event::assertDispatched(WebhookCallDispatchedEvent::class, 1);
 });


### PR DESCRIPTION
The idea for this PR came in regards of discussion #91, which introduced the idea of a database persistence layer. While this would be currently out of scope for this package, I figured that you could easily achieve everything the creator of the idea intended to do by utilising the package's events.

The only thing that was missing to allow persisting the webhook in whichever way the developer wants, was an event that is being fired exactly once when a new webhook is being dispatched (not to confuse with the dispatching of the job which could occur multiple times when retrying). For this reason, this PR adds the `WebhookCallDispatchedEvent` which fires when the `dispatch()` method for the `WebhookCall` object is being called.

One could then simply listen to the `WebhookCallDispatchedEvent`, persist it to the database and e.g. increase attempt counts or update the web hook's status based on fired `WebhookCallFailedEvent`s and `WebhookCallSucceededEvent`s.

I was unable to reuse the abstract `WebhookCallEvent` as it contains a lot of attributes that are specific to an actual attempt to send the webhook to its target URL.

Thank you for your work and of course no hard feelings if this PR is going to be declined.