### PR TITLE
Actually throw the exception when throwExceptionOnFailure is true

### DIFF
--- a/src/CallWebhookJob.php
+++ b/src/CallWebhookJob.php
@@ -116,7 +116,12 @@ class CallWebhookJob implements ShouldQueue
             if ($lastAttempt || $this->shouldBeRemovedFromQueue()) {
                 $this->dispatchEvent(FinalWebhookCallFailedEvent::class);
 
-                $this->throwExceptionOnFailure ? $this->fail($exception) : $this->delete();
+                if ($this->throwExceptionOnFailure) {
+                    $this->fail($exception);
+                    throw $exception;
+                } else {
+                    $this->delete();
+                }
             }
         }
     }


### PR DESCRIPTION
Before, this function called `fail($exception)` which does not throw an exception as intended. It only marks the job as failed.