### PR TITLE
Fix CallWebhookJob behaviour when throwExceptionOnFailure is true

### DIFF
--- a/src/CallWebhookJob.php
+++ b/src/CallWebhookJob.php
@@ -3,6 +3,7 @@
 namespace Spatie\WebhookServer;
 
 use Exception;
+use Throwable;
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\ConnectException;
@@ -185,5 +186,12 @@ class CallWebhookJob implements ShouldQueue
             "RAW" => $this->payload,
             default => json_encode($this->payload),
         };
+    }
+
+    public function failed(Throwable $e)
+    {
+        if ($this->throwExceptionOnFailure) {
+            throw $e;
+        }
     }
 }


### PR DESCRIPTION
Currently, the exceptions are not (re)thrown even if the `CallWebhookJob::$throwExceptionOnFailure` is set to `true`. 
By adding the `failed` method and re-throwing the exception here if the flag is set to `true` this issue should be fixed.